### PR TITLE
修复客户端 Setup 阶段调用 ItemProperties#register 引起的 ItemProperties#PROPERTIES 的 ConcurrentModificationException

### DIFF
--- a/src/main/java/net/byAqua3/avaritia/Avaritia.java
+++ b/src/main/java/net/byAqua3/avaritia/Avaritia.java
@@ -45,8 +45,10 @@ public class Avaritia {
 	}
 
 	private void clientSetup(final FMLClientSetupEvent event) {
-		AvaritiaItems.initItemProperties();
-		AvaritiaMenus.registerScreens();
+		event.enqueueWork(() -> {
+			AvaritiaItems.initItemProperties();
+			AvaritiaMenus.registerScreens();
+	        });
 	}
 
 	private void serverSetup(final FMLDedicatedServerSetupEvent event) {


### PR DESCRIPTION
完整崩溃信息：[minecraft-exported-crash-info-2025-01-02T22-27-51(1).zip](https://github.com/user-attachments/files/18302339/minecraft-exported-crash-info-2025-01-02T22-27-51.1.zip)
使用了[这个项目](https://github.com/Viola-Siemens/CME-Suck-My-Duck)完成 troubleshooting，发现您的模组与 travelersbackpack 和 musketmod 模组冲突，详细请看 CMESuckMyDuck.log。